### PR TITLE
Integrated GitHub analysis into connections algorithm.

### DIFF
--- a/backend/endpoints/connections.js
+++ b/backend/endpoints/connections.js
@@ -2,21 +2,23 @@
 
 const { connected } = require("process");
 
-module.exports = async function (app) {
+module.exports = async function (app, createOctokit, connectionsGraph) {
   const { PrismaClient } = require("@prisma/client");
   const prisma = new PrismaClient();
   const cors = require("cors");
   const express = require("express");
 
-  const GITHUB_SIMILARITY_POINTS = 40;
+  const GITHUB_SIMILARITY_POINTS = 50;
   const ADJACENT_PROFILE_SIMILARITY_POINTS = 30;
   const RECOMMENDER_PROFILE_SIMILARITY_POINTS = 15;
-  const RECENCY_POINTS = 15;
+  const RECENCY_POINTS = 5;
 
-  const SEED_RECENT_CONNECTIONS = 20; // Attempts to optimize time it takes to get connections while getting the most relevant recommendations.
+  const TOPIC_POINTS = 4;
+  const COMMON_LANGUAGE_POINTS = 6;
 
-  // Connections graph.
-  let connectionsGraph = {};
+  const SEED_RECENT_CONNECTIONS = 5; // Attempts to optimize time it takes to get connections while getting the most relevant recommendations.
+  const ANALYZE_REPOS = 5; // Limits how many recent repositories are looked at (max) for deep analysis.
+
   await createGraph();
 
   /***
@@ -64,6 +66,24 @@ module.exports = async function (app) {
   const tags = [];
 
   /***
+   * Returns the intersection of two sets.
+   */
+  function intersection(setOne, setTwo) {
+    const intersection = [];
+
+    for (setOneIndex in setOne) {
+      if (
+        setTwo.includes(setOne[setOneIndex]) &&
+        !intersection.includes(setOne[setOneIndex])
+      ) {
+        intersection.push(setOne[setOneIndex]);
+      }
+    }
+
+    return intersection;
+  }
+
+  /***
    * Calculates the Jaccard similarity between two sets by comparing arrays of similar objects.
    * Both sets should be IDs of the same objects.
    * Gets a score of 0 if there are no objects to compare.
@@ -83,11 +103,158 @@ module.exports = async function (app) {
   }
 
   /***
+   * Compares the similarities of the GitHubs of two users.
+   * Considers and weighs factors such as code breakdown of repositories, tags of repositories, etc.
+   * Uses the octokit of the user who the recommendation is being used for.
+   */
+  async function compareGitHubs(
+    userOneGitHubHandle,
+    userTwoGitHubHandle,
+    octokit
+  ) {
+    /***
+     * Gets GitHub information, including repository information.
+     */
+    async function getGitHubInfo(githubHandle) {
+      const repositoryResponse = await octokit.request(
+        "GET /users/{owner}/repos",
+        {
+          sort: "pushed",
+          owner: githubHandle,
+        }
+      );
+      const repositories = repositoryResponse.data;
+
+      let languages = {}; // Cumulative language makeup of recent repositories.
+      const topics = [];
+      let repositoriesIndex = 0;
+
+      // Looks at the 5 most recent repositories for analysis of languages and topics.
+
+      while (
+        repositoriesIndex < repositories.length &&
+        repositoriesIndex < ANALYZE_REPOS
+      ) {
+        // Getting and looking through data on repository languages.
+        const responseRepositoryLanguages = await octokit.request(
+          "GET /repos/{owner}/{repo}/languages",
+          {
+            owner: githubHandle,
+            repo: repositories[repositoriesIndex].name,
+            headers: {
+              "X-GitHub-Api-Version": "2022-11-28",
+            },
+          }
+        );
+
+        const repositoryLanguages = responseRepositoryLanguages.data;
+
+        const repositoryLanguagesNames = Object.keys(repositoryLanguages);
+
+        for (let languagesNameIndex in repositoryLanguagesNames) {
+          if (
+            repositoryLanguagesNames[languagesNameIndex] in
+            Object.keys(languages)
+          ) {
+            languages = {
+              ...lanaguages,
+              [repositoryLanguagesNames[languagesNameIndex]]:
+                languages[repositoryLanguagesNames[languagesNameIndex]] +
+                repositoryLanguages[
+                  repositoryLanguagesNames[languagesNameIndex]
+                ],
+            };
+          } else {
+            languages = {
+              ...languages,
+              [repositoryLanguagesNames[languagesNameIndex]]:
+                repositoryLanguages[
+                  repositoryLanguagesNames[languagesNameIndex]
+                ],
+            };
+          }
+        }
+
+        // Getting data on topics.
+        for (topicsIndex in repositories[repositoriesIndex].topics) {
+          if (
+            !topics.includes(
+              repositories[repositoriesIndex].topics[topicsIndex]
+            )
+          ) {
+            topics.push(repositories[repositoriesIndex].topics[topicsIndex]);
+          }
+        }
+
+        repositoriesIndex += 1;
+      }
+
+      const githubInfo = {
+        repositories: repositories,
+        recentRepositoryLanguages: languages,
+        recentTopics: topics,
+      };
+
+      return githubInfo;
+    }
+
+    const userOneGitHubInfo = await getGitHubInfo(userOneGitHubHandle);
+    const userTwoGitHubInfo = await getGitHubInfo(userTwoGitHubHandle);
+
+    // Calculating topic overlap.
+    // Topic similalrity can account for, max, two-fifths of GitHub similarity points.
+    const commonRepositoryTopicsCount = intersection(
+      userOneGitHubInfo.recentTopics,
+      userTwoGitHubInfo.recentTopics
+    );
+
+    let commonRepositoryTopicsScoring = 0;
+
+    if (userOneGitHubInfo.recentTopics === userTwoGitHubInfo.recentTopics) {
+      commonRepositoryTopicsScoring = 2 * (GITHUB_SIMILARITY_POINTS / 5);
+    } else {
+      commonRepositoryTopicsScoring =
+        commonRepositoryTopicsCount * TOPIC_POINTS >
+        2 * (GITHUB_SIMILARITY_POINTS / 5)
+          ? 2 * (GITHUB_SIMILARITY_POINTS / 5)
+          : commonRepositoryTopicsCount * TOPIC_POINTS;
+    }
+
+    // Comparing recent coding languages used.
+    // Language similalrity can account for, max, three-fifths of GitHub similarity points.
+    const commonGitHubLanguagesCount = intersection(
+      Object.keys(userOneGitHubInfo.recentRepositoryLanguages),
+      Object.keys(userTwoGitHubInfo.recentRepositoryLanguages)
+    ).length;
+
+    let commonGithubLanguagesScoring = 0;
+
+    if (
+      Object.keys(userOneGitHubInfo.recentRepositoryLanguages) ===
+      Object.keys(userTwoGitHubInfo.recentRepositoryLanguages)
+    ) {
+      commonGithubLanguagesScoring = 3 * (GITHUB_SIMILARITY_POINTS / 5);
+    } else {
+      commonGithubLanguagesScoring =
+        commonGitHubLanguagesCount * COMMON_LANGUAGE_POINTS >
+        3 * (GITHUB_SIMILARITY_POINTS / 5)
+          ? 3 * (GITHUB_SIMILARITY_POINTS / 5)
+          : commonGitHubLanguagesCount * COMMON_LANGUAGE_POINTS;
+    }
+
+    const githubScore =
+      commonRepositoryTopicsScoring + commonGithubLanguagesScoring;
+
+    return githubScore;
+  }
+
+  /***
    * Produces a score out of 100 giving how similar different two user profiles are, indicating if they should be recommended.
    */
-  async function getUserSimilarityScore(
+  async function getSyncProfileSimilarityScore(
     userOneID,
     userTwoID,
+    octokit,
     maxSimilarityPoints
   ) {
     /***
@@ -398,142 +565,167 @@ module.exports = async function (app) {
     "/connections/recommendations/:userID/:numberOfRecs",
     async (req, res) => {
       const userID = req.params.userID;
-      const numberOfRecs = req.params.numberOfRecs;
+      const numberOfRecs =
+        req.params.numberOfRecs > 5 ? 5 : req.params.numberOfRecs; // Sets max number of recs at one time to be 5 due to the number of GitHub request calls.
 
       const userConnectionsIDs = connectionsGraph[userID];
 
       const recommendations = [];
 
-      // Gets "weighted" recommendations based on how many connections the user and their connections have in common.
-      // The first n (numberOfRecs) are then returned.
-      // More connections are looked through if enough recommendations have not been generated and the user still has connections to use to generate related connections.
-      let weightedRecommendations = {};
+      if (userConnectionsIDs.length > 0) {
+        const userData = await prisma.user.findUnique({
+          where: { id: Number(userID) },
+        });
 
-      let connectionsPoolSize =
-        SEED_RECENT_CONNECTIONS <= userConnectionsIDs.length
-          ? SEED_RECENT_CONNECTIONS
-          : userConnectionsIDs.length; // Determines how many recent connections we will be using for generating recommendations at any given time. Either the seed, or, if less than the seed, the length of the recommendations.
-      let recencyPoints = RECENCY_POINTS; // Points for how recent a connection is. Cut by half each time we need to expand the pool we are looking for.
-      let count = 0; // Counts how many of the connections have been gone through.
+        // Gets "weighted" recommendations based on how many connections the user and their connections have in common.
+        // The first n (numberOfRecs) are then returned.
+        // More connections are looked through if enough recommendations have not been generated and the user still has connections to use to generate related connections.
+        let weightedRecommendations = {};
 
-      while (recommendations < numberOfRecs) {
-        // Retrieves the sorted connections of the user's connection (refered to as adjacent connections).
-        // Excludes the recommendee user's in adjacent connections before proceeding.
-        let adjacentConnectionsIDs = connectionsGraph[
-          String(userConnectionsIDs[count])
-        ].toSpliced(
-          connectionsGraph[String(userConnectionsIDs[count])].indexOf(
-            Number(userID)
-          ),
-          1
-        );
+        let connectionsPoolSize =
+          SEED_RECENT_CONNECTIONS <= userConnectionsIDs.length
+            ? SEED_RECENT_CONNECTIONS
+            : userConnectionsIDs.length; // Determines how many recent connections we will be using for generating recommendations at any given time. Either the seed, or, if less than the seed, the length of the recommendations.
+        let recencyPoints = RECENCY_POINTS; // Points for how recent a connection is. Cut by half each time we need to expand the pool we are looking for.
+        let count = 0; // Counts how many of the connections have been gone through.
 
-        const reversedAdjacentConnectionsIDs = [];
-        // Reverse the array to look at most recent connections first.
-        for (adjacentConnectionsIDsIndex in adjacentConnectionsIDs) {
-          reversedAdjacentConnectionsIDs.push(
-            adjacentConnectionsIDs[
-              adjacentConnectionsIDs.length - adjacentConnectionsIDsIndex - 1
-            ]
+        while (recommendations < numberOfRecs) {
+          // Retrieves the sorted connections of the user's connection (refered to as adjacent connections).
+          // Excludes the recommendee user's in adjacent connections before proceeding.
+          let adjacentConnectionsIDs = connectionsGraph[
+            String(userConnectionsIDs[count])
+          ].toSpliced(
+            connectionsGraph[String(userConnectionsIDs[count])].indexOf(
+              Number(userID)
+            ),
+            1
           );
-        }
 
-        adjacentConnectionsIDs = reversedAdjacentConnectionsIDs;
-
-        for (adjacentConnectionsIDsIndex in adjacentConnectionsIDs) {
-          // Checks if adjacent connection is already connected with user.
-          const connected = await prisma.connection.findMany({
-            where: {
-              OR: [
-                {
-                  AND: [
-                    { recipientID: Number(userID) },
-                    {
-                      senderID:
-                        adjacentConnectionsIDs[adjacentConnectionsIDsIndex],
-                    },
-                  ],
-                },
-                {
-                  AND: [
-                    {
-                      recipientID:
-                        adjacentConnectionsIDs[adjacentConnectionsIDsIndex],
-                    },
-                    { senderID: Number(userID) },
-                  ],
-                },
-              ],
-            },
-          });
-
-          // Calculates weights for recommendations if user is not connected with adjacent connection and has not requested a connection with that user.
-          if (connected.length === 0) {
-            const connectedUserRecommendationScore =
-              await getUserSimilarityScore(
-                Number(userID),
-                Number(userConnectionsIDs[count]),
-                RECOMMENDER_PROFILE_SIMILARITY_POINTS
-              );
-
-            const adjacentUserRecommendationScore =
-              await getUserSimilarityScore(
-                Number(userID),
-                adjacentConnectionsIDs[adjacentConnectionsIDsIndex],
-                ADJACENT_PROFILE_SIMILARITY_POINTS
-              );
-
-            // Recommendation score takes into accout the similarity of between the adjacent user and user and between the connected user and user.
-            const recommendationScore =
-              connectedUserRecommendationScore +
-              adjacentUserRecommendationScore +
-              recencyPoints;
-
-            weightedRecommendations = {
-              ...weightedRecommendations,
-              [adjacentConnectionsIDs[adjacentConnectionsIDsIndex]]:
-                recommendationScore,
-            };
+          const reversedAdjacentConnectionsIDs = [];
+          // Reverse the array to look at most recent connections first.
+          for (adjacentConnectionsIDsIndex in adjacentConnectionsIDs) {
+            reversedAdjacentConnectionsIDs.push(
+              adjacentConnectionsIDs[
+                adjacentConnectionsIDs.length - adjacentConnectionsIDsIndex - 1
+              ]
+            );
           }
-        }
 
-        // Gets the most highly relevant adjacent connections seen most frequently using the weighted connections values.
-        while (
-          recommendations.length < numberOfRecs &&
-          Object.keys(weightedRecommendations).length > 0
-        ) {
-          const highestRecommendationScore = Math.max(
-            Object.values(weightedRecommendations)
-          );
-          const hightestRecommendedUserID = Object.keys(
-            weightedRecommendations
-          ).find(
-            (recommenedUserID) =>
-              weightedRecommendations[recommenedUserID] ===
-              highestRecommendationScore
-          );
+          adjacentConnectionsIDs = reversedAdjacentConnectionsIDs;
 
-          recommendations.push(Number(hightestRecommendedUserID));
-          delete weightedRecommendations[hightestRecommendedUserID];
-        }
+          for (adjacentConnectionsIDsIndex in adjacentConnectionsIDs) {
+            // Checks if adjacent connection is already connected with user.
+            const connected = await prisma.connection.findMany({
+              where: {
+                OR: [
+                  {
+                    AND: [
+                      { recipientID: Number(userID) },
+                      {
+                        senderID:
+                          adjacentConnectionsIDs[adjacentConnectionsIDsIndex],
+                      },
+                    ],
+                  },
+                  {
+                    AND: [
+                      {
+                        recipientID:
+                          adjacentConnectionsIDs[adjacentConnectionsIDsIndex],
+                      },
+                      { senderID: Number(userID) },
+                    ],
+                  },
+                ],
+              },
+            });
 
-        count += 1;
-        recencyPoints /= 2;
+            // Gets the adjacent user's data.
+            const adjacentUserData = await prisma.user.findUnique({
+              where: {
+                id: adjacentConnectionsIDs[adjacentConnectionsIDsIndex],
+              },
+            });
 
-        // Widens the pool of recent connections to look through if algorithm hasn't yet found enough recommendations and there are more recommendations to look through.
-        if (count < connectionsPoolSize) {
-          continue;
-        } else if (
-          count < userConnectionsIDs.length &&
-          count >= connectionsPoolSize &&
-          recommendations.length < numberOfRecs
-        ) {
-          connectionsPoolSize =
-            connectionsPoolSize * 2 <= userConnectionsIDs.length
-              ? connectionsPoolSize * 2
-              : userConnectionsIDs.length; // Doubles the number of recent connections we want to look through if this is less than the number of recommendations.
-        } else {
-          break;
+            const octokit = await createOctokit(userData.githubHandle);
+
+            // Calculates weights for recommendations if user is not connected with adjacent connection and has not requested a connection with that user.
+            if (connected.length === 0) {
+              const connectedUserRecommendationScore =
+                await getSyncProfileSimilarityScore(
+                  Number(userID),
+                  Number(userConnectionsIDs[count]),
+                  octokit,
+                  RECOMMENDER_PROFILE_SIMILARITY_POINTS
+                );
+
+              const adjacentUserRecommendationScore =
+                await getSyncProfileSimilarityScore(
+                  Number(userID),
+                  adjacentConnectionsIDs[adjacentConnectionsIDsIndex],
+                  octokit,
+                  ADJACENT_PROFILE_SIMILARITY_POINTS
+                );
+
+              const githubScore = await compareGitHubs(
+                userData.githubHandle,
+                adjacentUserData.githubHandle,
+                octokit
+              );
+
+              // Recommendation score takes into accout the similarity of between the adjacent user and user and between the connected user and user.
+              const recommendationScore =
+                connectedUserRecommendationScore +
+                adjacentUserRecommendationScore +
+                githubScore +
+                recencyPoints;
+
+              weightedRecommendations = {
+                ...weightedRecommendations,
+                [adjacentConnectionsIDs[adjacentConnectionsIDsIndex]]:
+                  recommendationScore,
+              };
+            }
+          }
+
+          // Gets the most highly relevant adjacent connections seen most frequently using the weighted connections values.
+          while (
+            recommendations.length < numberOfRecs &&
+            Object.keys(weightedRecommendations).length > 0
+          ) {
+            const highestRecommendationScore = Math.max(
+              Object.values(weightedRecommendations)
+            );
+            const hightestRecommendedUserID = Object.keys(
+              weightedRecommendations
+            ).find(
+              (recommenedUserID) =>
+                weightedRecommendations[recommenedUserID] ===
+                highestRecommendationScore
+            );
+
+            recommendations.push(Number(hightestRecommendedUserID));
+            delete weightedRecommendations[hightestRecommendedUserID];
+          }
+
+          count += 1;
+          recencyPoints /= 2;
+
+          // Widens the pool of recent connections to look through if algorithm hasn't yet found enough recommendations and there are more recommendations to look through.
+          if (count < connectionsPoolSize) {
+            continue;
+          } else if (
+            count < userConnectionsIDs.length &&
+            count >= connectionsPoolSize &&
+            recommendations.length < numberOfRecs
+          ) {
+            connectionsPoolSize =
+              connectionsPoolSize * 2 <= userConnectionsIDs.length
+                ? connectionsPoolSize * 2
+                : userConnectionsIDs.length; // Doubles the number of recent connections we want to look through if this is less than the number of recommendations.
+          } else {
+            break;
+          }
         }
       }
 

--- a/backend/endpoints/github.js
+++ b/backend/endpoints/github.js
@@ -1,0 +1,47 @@
+// Uses of the GitHub REST API performed in the backend to utilize octokit instance.
+
+module.exports = function (app, createOctokit) {
+  const { PrismaClient } = require("@prisma/client");
+  const prisma = new PrismaClient();
+  const cors = require("cors");
+  const express = require("express");
+
+  /***
+   * Gets all of the GitHub repositories of some user given their GitHub handle.
+   */
+  app.get("/get-repos/:githubHandle", async (req, res) => {
+    const githubHandle = req.params.githubHandle;
+
+    const octokit = await createOctokit(githubHandle);
+
+    const repositories = await octokit.request("GET /users/{owner}/repos", {
+      owner: githubHandle,
+    });
+
+    res.status(200).json(repositories.data);
+  });
+
+  /***
+   * Gets all of the deployments of a specific repository given the user's GitHub handle and the name of the repository.
+   */
+  app.get(
+    "/all-deployments/:githubHandle/:repositoryName",
+    async (req, res) => {
+      const githubHandle = req.params.githubHandle;
+      const repositoryName = req.params.repositoryName;
+
+      const octokit = await createOctokit(githubHandle);
+
+      const deployments = await octokit.request(
+        "GET /repos/{owner}/{repo}/deployments",
+        {
+          owner: githubHandle,
+          repo: repositoryName,
+          headers: { "X-GitHub-Api-Version": "2022-11-28" },
+        }
+      );
+
+      res.status(200).json(deployments);
+    }
+  );
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@octokit/rest": "^19.0.0",
         "@prisma/client": "^5.16.0",
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
@@ -30,6 +31,129 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+      "dependencies": {
+        "@octokit/types": "^6.40.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+      "dependencies": {
+        "@octokit/types": "^6.39.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.0.tgz",
+      "integrity": "sha512-WrddtZvegoqARLEvx9MeBYNe3JHLXUlxGLm09R+t6RZOo4tOCD9SAUrzB4rn0fPz6rMFYGCv6L27Q6edcg1gkA==",
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^12.11.0"
       }
     },
     "node_modules/@prisma/client": {
@@ -186,6 +310,11 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -351,6 +480,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/destroy": {
       "version": "1.2.0",
@@ -746,6 +880,14 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lodash": {
@@ -1297,6 +1439,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@octokit/rest": "^19.0.0",
     "@prisma/client": "^5.16.0",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import {
 } from "react-router-dom";
 import { CookiesProvider, useCookies } from "react-cookie";
 import { Suspense, lazy, useState } from "react";
+import { USER } from "./pages/util/enums";
 import LoadingPage from "./pages/LoadingPage";
 import Page404 from "./pages/Page404";
 
@@ -34,12 +35,11 @@ const FeaturedProjectCreationPage = lazy(() =>
   import("./pages/FeaturedProjectCreationPage")
 );
 
-
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 
 function App() {
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
 
   // For routes requiring that the user is logged in.
   const PrivateRoutes = () => {
@@ -81,6 +81,7 @@ function App() {
                   path="/create-featured"
                   element={<FeaturedProjectCreationPage />}
                 />
+                <Route
                   path="/connections/pending"
                   element={<PendingConnectionsPage />}
                 />

--- a/frontend/src/components/CommentFamily.jsx
+++ b/frontend/src/components/CommentFamily.jsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { createComment, generateDateTimestamp } from "../pages/util/posts";
+import { useCookies } from "react-cookie";
+import { USER } from "./../pages/util/enums";
 
 import "./stylesheets/CommentFamily.css";
-import { useCookies } from "react-cookie";
 
 function CommentFamily(commentFamily) {
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
   const [parentReplyOpen, setParentReplyOpen] = useState(false);
   const [parentReplyText, setParentReplyText] = useState("");
 

--- a/frontend/src/components/Connection.jsx
+++ b/frontend/src/components/Connection.jsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import { getUserDataID } from "../pages/util/posts";
 import { useNavigate } from "react-router";
+import { USER } from "../pages/util/enums";
 
 import "./stylesheets/Connection.css";
 
 function Connection(connectionInfo) {
   const navigate = useNavigate();
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
 
   return (
     <span

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -1,11 +1,13 @@
 import { useCookies } from "react-cookie";
 import { upvotePost } from "../pages/util/posts";
 import { useNavigate } from "react-router-dom";
-import "./stylesheets/Post.css";
+import { USER } from "../pages/util/enums";
 import { useState } from "react";
 
+import "./stylesheets/Post.css";
+
 function Post(postInfo) {
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
   const [upvotes, setUpvotes] = useState(postInfo.postInfo.upvoteCount);
 
   const navigate = useNavigate();

--- a/frontend/src/pages/ConnectionsPage.jsx
+++ b/frontend/src/pages/ConnectionsPage.jsx
@@ -1,6 +1,7 @@
 import { useCookies } from "react-cookie";
 import { getConnections, getRecommendedUsers } from "./util/connections";
 import { useState, useEffect } from "react";
+import { USER } from "./util/enums";
 
 import LoadingPage from "./LoadingPage";
 import Connection from "../components/Connection";
@@ -8,7 +9,7 @@ import Connection from "../components/Connection";
 const NUMBER_OF_RECOMMENDATIONS = 5;
 
 function ConnectionsPage() {
-  const [cookies] = useCookies(["user"]);
+  const [cookies] = useCookies([USER]);
   const [userConnectionsData, setUserConnectionsData] = useState([]);
   const [recommendedUsersData, setRecommendedUsersData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/pages/FeaturedProjectCreationPage.jsx
+++ b/frontend/src/pages/FeaturedProjectCreationPage.jsx
@@ -1,14 +1,13 @@
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
-import {
-  getAllDeployments,
-  getGitHubRepositories,
-} from "./util/featuredProjects";
+import { getAllDeployments, getGitHubRepositories } from "./util/github";
+import { USER } from "./util/enums";
+
 import LoadingPage from "./LoadingPage";
 import FeaturedPostOption from "../components/FeaturedPostOption";
 
 function FeaturedPostCreationPage() {
-  const [cookies] = useCookies(["user"]);
+  const [cookies] = useCookies([USER]);
   const [isLoading, setIsLoading] = useState(true);
   const [githubRepositories, setGitHubRepositories] = useState([]);
   const [deployedGitHubRepos, setDeployedGitHubRepos] = useState({}); //Deployed repository with the key being the GitHub URL and value being an array of the deployed repositories.
@@ -18,15 +17,17 @@ function FeaturedPostCreationPage() {
       const loadedGitHubRepositories = await getGitHubRepositories(
         cookies.user.githubHandle
       );
-      setGitHubRepositories(loadedGitHubRepositories);
+      await setGitHubRepositories(loadedGitHubRepositories);
 
       for (const repositoryIndex in loadedGitHubRepositories) {
         const repositoryName = loadedGitHubRepositories[repositoryIndex].name;
+
         const loadedDeployments = await getAllDeployments(
           cookies.user.githubHandle,
           repositoryName
         );
-        setDeployedGitHubRepos((previousDeployedGitHubRepos) => ({
+
+        await setDeployedGitHubRepos((previousDeployedGitHubRepos) => ({
           ...previousDeployedGitHubRepos,
           [repositoryName]: loadedDeployments,
         }));

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -7,18 +7,13 @@ import {
   createPost,
   generateDateTimestamp,
 } from "./util/posts";
+import { USER, TITLE, TEXT, MEDIA, TAGS } from "./util/enums";
 import Post from "../components/Post";
 import LoadingPage from "./LoadingPage";
 
 import "./stylesheets/HomePage.css";
 
 function HomePage() {
-  // Enums for post and feed data.
-  const TITLE = "title";
-  const TEXT = "text";
-  const MEDIA = "media";
-  const TAGS = "tags";
-
   // Modal useStates.
   const [modalOpen, setModalOpen] = useState(false);
   const [postContent, setPostContent] = useState({
@@ -30,7 +25,7 @@ function HomePage() {
   const [titleInvalidWarning, setTitleInvalidWarning] = useState(false);
   const [textInvalidWarning, setTextInvalidWarning] = useState(false);
 
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
   const [isLoading, setIsLoading] = useState(true);
   const [userData, setUserData] = useState({});
   const [feedData, setFeedData] = useState([]);
@@ -41,7 +36,7 @@ function HomePage() {
    * Helper function for logging out.
    */
   function logOut() {
-    removeCookies("user", { path: "/" });
+    removeCookies(USER, { path: "/" });
     navigate("/login");
   }
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -2,11 +2,12 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { handleLogin } from "./util/auth";
 import { useCookies } from "react-cookie";
+import { USER } from "./util/enums";
 
 import "./stylesheets/LoginPage.css";
 
 function LoginPage() {
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
   const [user, setUser] = useState("");
   const [password, setPassword] = useState("");
 
@@ -35,7 +36,7 @@ function LoginPage() {
         const userData = loginData[1];
 
         if (validLogin) {
-          setCookies("user", userData, { path: "/", maxAge: 3600 });
+          setCookies(USER, userData, { path: "/", maxAge: 3600 });
           navigate("/");
         }
       } else {

--- a/frontend/src/pages/PendingConnectionsPage.jsx
+++ b/frontend/src/pages/PendingConnectionsPage.jsx
@@ -1,13 +1,14 @@
 import { useState, useEffect } from "react";
 import { useCookies } from "react-cookie";
 import { getPendingConnections } from "./util/connections";
+import { USER } from "./util/enums";
 
 import LoadingPage from "./LoadingPage";
 import Connection from "../components/Connection";
 import "./stylesheets/PendingConnections.css";
 
 function PendingConnections() {
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
   const [pendingConnections, setPendingConnections] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 

--- a/frontend/src/pages/PostPage.jsx
+++ b/frontend/src/pages/PostPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useCookies } from "react-cookie";
 import { getPost, generateDateTimestamp, createComment } from "./util/posts";
+import { USER } from "./util/enums";
 
 import "./stylesheets/PostPage.css";
 import LoadingPage from "./LoadingPage";
@@ -12,7 +13,7 @@ const postID = postURL[postURL.length - 1];
 
 function Post() {
   const [isLoading, setIsLoading] = useState(true);
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
   const [postData, setPostData] = useState({});
   const [commentData, setCommentData] = useState([]);
   const [postAuthorData, setPostAuthorData] = useState([]);

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -11,7 +11,7 @@ import { useNavigate } from "react-router-dom";
 import Post from "../components/Post";
 import FeaturedProject from "../components/FeaturedProject";
 import LoadingPage from "./LoadingPage";
-
+import { USER } from "./util/enums";
 import { CONNECT_STATUS } from "./util/enums";
 
 import "./stylesheets/ProfilePage.css";
@@ -23,7 +23,7 @@ const profileURL = window.location.href.split("/");
 const profileUser = profileURL[profileURL.length - 1];
 
 function ProfilePage() {
-  const [cookies, setCookies, removeCookies] = useCookies(["user"]);
+  const [cookies, setCookies, removeCookies] = useCookies([USER]);
   const [profileUserData, setProfileUserData] = useState({});
   const [userPosts, setUserPosts] = useState([]);
   const [featuredProjects, setFeaturedProjects] = useState([]);

--- a/frontend/src/pages/SignUpPage.jsx
+++ b/frontend/src/pages/SignUpPage.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { handleSignUp, getGithubIdentity } from "./util/auth";
-import { Octokit } from "@octokit/rest";
 
 import "./stylesheets/SignUpPage.css";
 

--- a/frontend/src/pages/util/auth.js
+++ b/frontend/src/pages/util/auth.js
@@ -88,6 +88,11 @@ export async function handleSignUp(loginInfo) {
         }),
       });
 
+      const response = await fetch(`${DATABASE}/user/${userHandle}`);
+      const userData = await response.json();
+
+      localStorage.setItem("userID", userData.id);
+
       return userCreation.ok;
     } catch (err) {}
   } else {
@@ -149,9 +154,11 @@ export async function githubAuthentication() {
   const clientID = GITHUB_CLIENT_ID;
   const clientSecret = GITHUB_CLIENT_SECRET;
 
+  const userID = localStorage.getItem("userID");
+
   if (code && state) {
     if (state === localStorage.getItem("CSRFToken")) {
-      const response = await fetch(`${DATABASE}/token-auth`, {
+      await fetch(`${DATABASE}/token-auth/${userID}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -162,24 +169,11 @@ export async function githubAuthentication() {
           code: code,
         }),
       });
-
-      const token = await response.json();
-
-      if (token.access_token) {
-        // Successful request and retrieval of token.
-        // Store in database.
-      } else {
-        // Invalid or already fuffilled request for access token.
-        if (localStorage.getItem("gitHubAuthToken")) {
-          // Already fuffilled.
-        } else {
-          // Invalid request.
-        }
-      }
     } else {
       // Authentication failed.
     }
 
+    localStorage.removeItem("userID");
     window.location.assign(`${WEB_ADDRESS}/login`);
   } else {
     // Codes don't match.

--- a/frontend/src/pages/util/enums.js
+++ b/frontend/src/pages/util/enums.js
@@ -3,9 +3,32 @@ const REQUESTED = "requested";
 const RESPOND = "respond";
 const NOT_CONNECTED = "not connected";
 
+export const USER = "user";
+
 export const CONNECT_STATUS = {
   CONNECTED,
   REQUESTED,
   RESPOND,
   NOT_CONNECTED,
 };
+
+export const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+// Enums for post and feed data.
+export const TITLE = "title";
+export const TEXT = "text";
+export const MEDIA = "media";
+export const TAGS = "tags";

--- a/frontend/src/pages/util/github.js
+++ b/frontend/src/pages/util/github.js
@@ -1,12 +1,14 @@
+const DATABASE = import.meta.env.VITE_DATABASE_ACCESS;
+
 /***
  * Retrieves all GitHub repositories for the specified user given a user handle.
  */
 export async function getGitHubRepositories(githubHandle) {
   try {
-    const response = await fetch(
-      `https://api.github.com/users/${githubHandle}/repos`
-    );
-    const repositories = await response.json();
+    const response = await fetch(`${DATABASE}/get-repos/${githubHandle}`);
+
+    const repositories = response.json();
+
     return repositories;
   } catch {
     // Unable to retrieve repositories.
@@ -17,12 +19,13 @@ export async function getGitHubRepositories(githubHandle) {
  * Gets all deployments for a specific repository.
  * Returns an array of deployment info, including the deployment IDs that can later be used to retrieve a specific deployment.
  */
-export async function getAllDeployments(githubHandle, githubRepositoryName) {
+export async function getAllDeployments(githubHandle, repositoryName) {
   try {
     const response = await fetch(
-      `https://api.github.com/repos/${githubHandle}/${githubRepositoryName}/deployments`
+      `${DATABASE}/all-deployments/${githubHandle}/${repositoryName}`
     );
-    const deployments = await response.json();
+
+    const deployments = response.json();
 
     return deployments;
   } catch {

--- a/frontend/src/pages/util/posts.js
+++ b/frontend/src/pages/util/posts.js
@@ -1,3 +1,5 @@
+import { MONTHS } from "./enums";
+
 const DATABASE = import.meta.env.VITE_DATABASE_ACCESS;
 const WEB_ADDRESS = import.meta.env.VITE_WEB_ADDRESS;
 
@@ -155,21 +157,6 @@ export async function getComments(postID) {
  */
 export function generateDateTimestamp() {
   // Generate date and timestamp.
-  const MONTHS = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ];
-
   const dateObject = new Date();
 
   const month = dateObject.getMonth();

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sync",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description
**ABOUT**
- New code gets GitHub information of two users and compares them for connection recommendations
- Comparisons of GitHub take into consideration (1) topics on the GitHub recent repositories, and (2) languages used in recent GitHub repositories
- Comparisons of GitHub are then used to generate connection recommendations
- Current max points breakdown for the connection recommendation algorithm:
  - GitHub comparison = 50 points 
  - Adjacent profile comparison = 30 points
  - Recommender profile comparison = 15 points
  - Recent connection points = 5 points

Later PRs may edit this algorithm to make more accurate recommendations. 

## Milestones
**USER STORIES:**
- User can see some information on recommended posts and users ✅

## Test Plan
- Tested by getting a fellow intern (shout out Faustina Uba!!) to sign up for my website with her GitHub account to see how comparisons work
- Recommendation example for the signed in user (me, @/dezok) where Amy Okonkwo (@/amy) was my connection and Faustina (@/faustina) was connected to Amy show in image and video below
- Also, tested with two individuals where one individual did not yet have repositories (created fake account for @/amy)

**MEDIA**
**Video on Loom:**
https://www.loom.com/share/405fc2d9e5924fdb80f1381717c27ff9?sid=7cdf84a2-1534-4002-83e2-9bd5f1035b8f

**Images:** 
<img width="1728" alt="Screenshot 2024-07-14 at 7 03 20 PM" src="https://github.com/user-attachments/assets/0bd5a92b-0cf8-4038-a955-a67b9df5185f">
